### PR TITLE
optimize readUntilPrompt

### DIFF
--- a/pkg/netrasp/reader.go
+++ b/pkg/netrasp/reader.go
@@ -1,6 +1,7 @@
 package netrasp
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -10,6 +11,10 @@ import (
 )
 
 var errRead = errors.New("reader error")
+var repl = strings.NewReplacer("\r\n", "\n", "\r", "\n")
+
+var minReadSize = 10000
+var maxReadSize = 10 * 1000 * 1000
 
 type contextReader struct {
 	ctx context.Context
@@ -55,7 +60,7 @@ func newContextReader(ctx context.Context, r io.Reader) io.Reader {
 }
 
 // readUntilPrompt reads until the specified prompt is found and returns the read data.
-func readUntilPrompt(ctx context.Context, r io.Reader, prompt *regexp.Regexp) (string, error) {
+func readUntilPromptOriginal(ctx context.Context, r io.Reader, prompt *regexp.Regexp) (string, error) {
 	var output string
 	r = newContextReader(ctx, r)
 	for {
@@ -80,4 +85,55 @@ func readUntilPrompt(ctx context.Context, r io.Reader, prompt *regexp.Regexp) (s
 	}
 
 	return output, nil
+}
+
+// readUntilPrompt reads until the specified prompt is found and returns the read data.
+func readUntilPromptWithStringsBuilder(ctx context.Context, r io.Reader, prompt *regexp.Regexp) (string, error) {
+	var output = strings.Builder{}
+	rc := newContextReader(ctx, r)
+	readSize := minReadSize
+	for {
+		buffer := make([]byte, readSize)
+
+		n, err := rc.Read(buffer)
+		if err != nil {
+			return "", fmt.Errorf("error reading output from device %w: %v", errRead, err)
+		}
+		if readSize == n && readSize < maxReadSize {
+			readSize *= 2
+		}
+		output.Write(buffer[:n])
+		workingOutput := repl.Replace(output.String())
+		if prompt.MatchString(workingOutput[strings.LastIndex(workingOutput, "\n")+1:]) {
+			break
+		}
+	}
+
+	return output.String(), nil
+}
+
+// readUntilPrompt reads until the specified prompt is found and returns the read data.
+func readUntilPrompt(ctx context.Context, r io.Reader, prompt *regexp.Regexp) (string, error) {
+	var output = new(bytes.Buffer)
+	rc := newContextReader(ctx, r)
+	readSize := minReadSize
+	for {
+		b := make([]byte, readSize)
+
+		n, err := rc.Read(b)
+		if err != nil {
+			return "", fmt.Errorf("error reading output from device %w: %v", errRead, err)
+		}
+		if readSize == n && readSize < maxReadSize {
+			readSize *= 2
+		}
+		output.Write(b[:n])
+		tempSlice := bytes.ReplaceAll(output.Bytes(), []byte("\r\n"), []byte("\n"))
+		tempSlice = bytes.ReplaceAll(tempSlice, []byte("\r"), []byte("\n"))
+		if prompt.Match(tempSlice[bytes.LastIndex(tempSlice, []byte("\n"))+1:]) {
+			break
+		}
+	}
+
+	return output.String(), nil
 }

--- a/pkg/netrasp/reader_test.go
+++ b/pkg/netrasp/reader_test.go
@@ -11,6 +11,8 @@ var testReaderBasic = `
 here is your string
 router1#`
 
+var ns string
+
 func TestReader(t *testing.T) {
 	r := strings.NewReader(testReaderBasic)
 
@@ -32,4 +34,111 @@ func TestReaderTimeout(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected reader to timeout, but got %v", out)
 	}
+}
+
+func generatePrompt(lines int) string {
+	return strings.Repeat(strings.Repeat("dummy", 10)+"\r\r\n", lines-1) + "prompt#"
+}
+
+func runBenchmarkReaderOriginalNLines(b *testing.B, i int) {
+	b.Helper()
+	var s string
+	var err error
+
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		r := strings.NewReader(generatePrompt(i))
+		s, err = readUntilPromptOriginal(context.Background(), r, generalPrompt)
+		if err != nil {
+			b.Fail()
+		}
+	}
+	ns = s
+}
+
+func runBenchmarkReaderStringsBuilderNLines(b *testing.B, i int) {
+	b.Helper()
+	var s string
+	var err error
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		r := strings.NewReader(generatePrompt(i))
+		s, err = readUntilPromptWithStringsBuilder(context.Background(), r, generalPrompt)
+		if err != nil {
+			b.Fail()
+		}
+	}
+	ns = s
+}
+
+func runBenchmarkReaderBytesBufferNLines(b *testing.B, i int) {
+	b.Helper()
+	var s string
+	var err error
+	b.ReportAllocs()
+	for n := 0; n < b.N; n++ {
+		r := strings.NewReader(generatePrompt(i))
+		s, err = readUntilPrompt(context.Background(), r, generalPrompt)
+		if err != nil {
+			b.Fail()
+		}
+	}
+	ns = s
+}
+
+// 1K lines.
+func BenchmarkReaderOriginal100Lines(b *testing.B) {
+	runBenchmarkReaderOriginalNLines(b, 100)
+}
+func BenchmarkReaderStringsBuilder100Lines(b *testing.B) {
+	runBenchmarkReaderStringsBuilderNLines(b, 100)
+}
+func BenchmarkReaderBytesBuffer100Lines(b *testing.B) {
+	runBenchmarkReaderBytesBufferNLines(b, 100)
+}
+
+// 1K lines.
+func BenchmarkReaderOriginal1KLines(b *testing.B) {
+	runBenchmarkReaderOriginalNLines(b, 1000)
+}
+func BenchmarkReaderStringsBuilder1KLines(b *testing.B) {
+	runBenchmarkReaderStringsBuilderNLines(b, 1000)
+}
+func BenchmarkReaderBytesBuffer1KLines(b *testing.B) {
+	runBenchmarkReaderBytesBufferNLines(b, 1000)
+}
+
+// 10K lines.
+func BenchmarkReaderOriginal10KLines(b *testing.B) {
+	runBenchmarkReaderOriginalNLines(b, 10000)
+}
+func BenchmarkReaderStringsBuilder10KLines(b *testing.B) {
+	runBenchmarkReaderStringsBuilderNLines(b, 10000)
+}
+func BenchmarkReaderBytesBuffer10KLines(b *testing.B) {
+	runBenchmarkReaderBytesBufferNLines(b, 10000)
+}
+
+// 50k Lines.
+func BenchmarkReaderOriginal50KLines(b *testing.B) {
+	runBenchmarkReaderOriginalNLines(b, 50000)
+}
+func BenchmarkReaderStringsBuilder50KLines(b *testing.B) {
+	runBenchmarkReaderStringsBuilderNLines(b, 50000)
+}
+func BenchmarkReaderBytesBuffer50KLines(b *testing.B) {
+	runBenchmarkReaderBytesBufferNLines(b, 50000)
+}
+
+// 100k Lines.
+func BenchmarkReaderOriginal100KLines(b *testing.B) {
+	runBenchmarkReaderOriginalNLines(b, 100000)
+}
+
+func BenchmarkReaderStringsBuilder100KLines(b *testing.B) {
+	runBenchmarkReaderStringsBuilderNLines(b, 100000)
+}
+
+func BenchmarkReaderBytesBuffer100KLines(b *testing.B) {
+	runBenchmarkReaderBytesBufferNLines(b, 100000)
 }

--- a/pkg/netrasp/reader_test.go
+++ b/pkg/netrasp/reader_test.go
@@ -40,37 +40,6 @@ func generatePrompt(lines int) string {
 	return strings.Repeat(strings.Repeat("dummy", 10)+"\r\r\n", lines-1) + "prompt#"
 }
 
-func runBenchmarkReaderOriginalNLines(b *testing.B, i int) {
-	b.Helper()
-	var s string
-	var err error
-
-	b.ReportAllocs()
-	for n := 0; n < b.N; n++ {
-		r := strings.NewReader(generatePrompt(i))
-		s, err = readUntilPromptOriginal(context.Background(), r, generalPrompt)
-		if err != nil {
-			b.Fail()
-		}
-	}
-	ns = s
-}
-
-func runBenchmarkReaderStringsBuilderNLines(b *testing.B, i int) {
-	b.Helper()
-	var s string
-	var err error
-	b.ReportAllocs()
-	for n := 0; n < b.N; n++ {
-		r := strings.NewReader(generatePrompt(i))
-		s, err = readUntilPromptWithStringsBuilder(context.Background(), r, generalPrompt)
-		if err != nil {
-			b.Fail()
-		}
-	}
-	ns = s
-}
-
 func runBenchmarkReaderBytesBufferNLines(b *testing.B, i int) {
 	b.Helper()
 	var s string
@@ -86,59 +55,27 @@ func runBenchmarkReaderBytesBufferNLines(b *testing.B, i int) {
 	ns = s
 }
 
-// 1K lines.
-func BenchmarkReaderOriginal100Lines(b *testing.B) {
-	runBenchmarkReaderOriginalNLines(b, 100)
-}
-func BenchmarkReaderStringsBuilder100Lines(b *testing.B) {
-	runBenchmarkReaderStringsBuilderNLines(b, 100)
-}
+// 100 lines.
 func BenchmarkReaderBytesBuffer100Lines(b *testing.B) {
 	runBenchmarkReaderBytesBufferNLines(b, 100)
 }
 
 // 1K lines.
-func BenchmarkReaderOriginal1KLines(b *testing.B) {
-	runBenchmarkReaderOriginalNLines(b, 1000)
-}
-func BenchmarkReaderStringsBuilder1KLines(b *testing.B) {
-	runBenchmarkReaderStringsBuilderNLines(b, 1000)
-}
 func BenchmarkReaderBytesBuffer1KLines(b *testing.B) {
 	runBenchmarkReaderBytesBufferNLines(b, 1000)
 }
 
 // 10K lines.
-func BenchmarkReaderOriginal10KLines(b *testing.B) {
-	runBenchmarkReaderOriginalNLines(b, 10000)
-}
-func BenchmarkReaderStringsBuilder10KLines(b *testing.B) {
-	runBenchmarkReaderStringsBuilderNLines(b, 10000)
-}
 func BenchmarkReaderBytesBuffer10KLines(b *testing.B) {
 	runBenchmarkReaderBytesBufferNLines(b, 10000)
 }
 
 // 50k Lines.
-func BenchmarkReaderOriginal50KLines(b *testing.B) {
-	runBenchmarkReaderOriginalNLines(b, 50000)
-}
-func BenchmarkReaderStringsBuilder50KLines(b *testing.B) {
-	runBenchmarkReaderStringsBuilderNLines(b, 50000)
-}
 func BenchmarkReaderBytesBuffer50KLines(b *testing.B) {
 	runBenchmarkReaderBytesBufferNLines(b, 50000)
 }
 
 // 100k Lines.
-func BenchmarkReaderOriginal100KLines(b *testing.B) {
-	runBenchmarkReaderOriginalNLines(b, 100000)
-}
-
-func BenchmarkReaderStringsBuilder100KLines(b *testing.B) {
-	runBenchmarkReaderStringsBuilderNLines(b, 100000)
-}
-
 func BenchmarkReaderBytesBuffer100KLines(b *testing.B) {
 	runBenchmarkReaderBytesBufferNLines(b, 100000)
 }


### PR DESCRIPTION
As discussed in #16, this PR tries to optimize the function reading from the ssh stdout until a prompt is detected.

Compared to what I posted in #16 I was able to further reduce the allocations (and overall performance)  by doubling the number of bytes read if the previous Read filled the buffer (bytes slice), meaning that there is probably more bytes to read. 
The doubling is capped at 10MB.

```
goos: linux
goarch: amd64
pkg: github.com/networklore/netrasp/pkg/netrasp
BenchmarkReaderOriginal100Lines            89144             13693 ns/op           51681 B/op         20 allocs/op
BenchmarkReaderStringsBuilder100Lines      77240             14421 ns/op           37649 B/op         16 allocs/op
BenchmarkReaderBytesBuffer100Lines        118660             10312 ns/op           42993 B/op         16 allocs/op

BenchmarkReaderOriginal1KLines              2932            411502 ns/op         1412229 B/op         85 allocs/op
BenchmarkReaderStringsBuilder1KLines        6068            200693 ns/op          496834 B/op         36 allocs/op
BenchmarkReaderBytesBuffer1KLines           8080            150125 ns/op          603238 B/op         34 allocs/op

BenchmarkReaderOriginal10KLines               40          29014998 ns/op        82506028 B/op        761 allocs/op
BenchmarkReaderStringsBuilder10KLines        476           2545300 ns/op         5192044 B/op         69 allocs/op
BenchmarkReaderBytesBuffer10KLines           732           1674131 ns/op         5806319 B/op         63 allocs/op

BenchmarkReaderOriginal50KLines                2         717873436 ns/op        1966611204 B/op     3955 allocs/op
BenchmarkReaderStringsBuilder50KLines         64          18521338 ns/op        31493692 B/op        102 allocs/op
BenchmarkReaderBytesBuffer50KLines            94          12372473 ns/op        37513008 B/op         94 allocs/op

BenchmarkReaderOriginal100KLines               1        3018512224 ns/op        7817554600 B/op     8220 allocs/op
BenchmarkReaderStringsBuilder100KLines        34          34133189 ns/op        62915612 B/op        112 allocs/op
BenchmarkReaderBytesBuffer100KLines           54          22204790 ns/op        68265700 B/op        102 allocs/op
PASS
ok      github.com/networklore/netrasp/pkg/netrasp      21.662s
```

I left the original function, the one using `strings.Builder` and the related benchmarks for reference. Let me know if you want me to clean them up.