### PR TITLE
Initial code for ConfigResult

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,12 @@ github.com/magefile/mage v1.11.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXq
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c h1:9HhBz5L/UjnK9XLtiZhYAdue5BVKep3PMmS2LuPDt8k=
 golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/netrasp/config.go
+++ b/pkg/netrasp/config.go
@@ -1,0 +1,14 @@
+package netrasp
+
+// ConfigResult is returned by a Configure operation and contains output and results.
+type ConfigResult struct {
+	ConfigCommands []ConfigCommand
+}
+
+// ConfigCommand contains a configuration command together with the output from that command.
+type ConfigCommand struct {
+	// The command that was sent to the device
+	Command string
+	// The output seen after entering the command
+	Output string
+}

--- a/pkg/netrasp/ios.go
+++ b/pkg/netrasp/ios.go
@@ -23,25 +23,26 @@ func (i ios) Close(ctx context.Context) error {
 }
 
 // Configure device.
-func (i ios) Configure(ctx context.Context, commands []string) (string, error) {
-	var output string
+func (i ios) Configure(ctx context.Context, commands []string) (ConfigResult, error) {
+	var result ConfigResult
 	_, err := i.Run(ctx, "configure terminal")
 	if err != nil {
-		return "", fmt.Errorf("unable to enter config mode: %w", err)
+		return result, fmt.Errorf("unable to enter config mode: %w", err)
 	}
 	for _, command := range commands {
-		result, err := i.Run(ctx, command)
+		output, err := i.Run(ctx, command)
+		configCommand := ConfigCommand{Command: command, Output: output}
+		result.ConfigCommands = append(result.ConfigCommands, configCommand)
 		if err != nil {
-			return output, fmt.Errorf("unable to run command '%s': %w", command, err)
+			return result, fmt.Errorf("unable to run command '%s': %w", command, err)
 		}
-		output += result
 	}
 	_, err = i.Run(ctx, "end")
 	if err != nil {
-		return output, fmt.Errorf("unable to exit from config mode: %w", err)
+		return result, fmt.Errorf("unable to exit from config mode: %w", err)
 	}
 
-	return output, nil
+	return result, nil
 }
 
 // Dial opens a connection to a device.

--- a/pkg/netrasp/platform.go
+++ b/pkg/netrasp/platform.go
@@ -13,7 +13,7 @@ type Platform interface {
 	// Disconnect from a device
 	Close(context.Context) error
 	// Configure device with the provided commands
-	Configure(context.Context, []string) (string, error)
+	Configure(context.Context, []string) (ConfigResult, error)
 	// Open a connection to a device
 	Dial(context.Context) error
 	// Elevate privileges on device


### PR DESCRIPTION
This PR modified the method signature for Configure as described in #18.
It doesn't cover all features described in that issue. As it's a
breaking change for the early API it would be good to merge it sooner
rather than later and add to it once it's in place.